### PR TITLE
Fix pawn movement at 0% and add crafting recipe

### DIFF
--- a/About/HediffComp_PartEfficiency.cs
+++ b/About/HediffComp_PartEfficiency.cs
@@ -40,7 +40,7 @@ namespace PhantomLimbs
         {
             if (!isActive)
             {
-                return 0f; // Inactive limbs have 0 efficiency
+                return 0.0001f; // Inactive limbs have effectively 0 efficiency
             }
             return initialEfficiency ?? parent.def.addedPartProps?.partEfficiency ?? 1f;
         }

--- a/Defs/PhantomLimbs_Defs.xml
+++ b/Defs/PhantomLimbs_Defs.xml
@@ -148,6 +148,9 @@
     <products>
       <phantomlimbImplant>1</phantomlimbImplant>
     </products>
+    <recipeUsers>
+      <li>CraftingSpot</li>
+    </recipeUsers>
   </RecipeDef>
 
   <ResearchProjectDef>


### PR DESCRIPTION
This commit addresses two issues:

1. Pawns with phantom limbs were still able to move even when their moving capacity was displayed as 0%. This was caused by setting the part efficiency to exactly 0. The fix is to set the efficiency to a very small, non-zero value (0.0001f), which effectively disables movement without triggering the game engine's quirk.

2. The crafting recipe for the phantom limb implant was not available at the crafting spot. This was fixed by adding the 'CraftingSpot' to the 'recipeUsers' list in the recipe definition.